### PR TITLE
Passed spec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/spec/bank_spec.rb
+++ b/spec/bank_spec.rb
@@ -2,23 +2,23 @@ require 'vcr'
 require_relative 'spec_helper'
 require_relative '../lib/bank'
 
-RSpec.describe Bank do
+RSpec.describe ZenginBankGem::Bank do
 
   attr_accessor :bank
   before do
     @bank = 
-      Zengin.banks.each.find do |bank|
+      ZenginBankGem.banks.each.find do |bank|
         bank.bank_name == "愛知銀行"
       end
   end
 
   describe '#branches' do
-    it 'branchesを呼んだ時にBranchCollectionが返る' do
-      expect(bank.branches).to be_kind_of(Bank::BranchCollection)
+    it 'branchesを呼んだ時にZenginBankGem::Bank::BranchCollectionが返る' do
+      expect(bank.branches).to be_kind_of(ZenginBankGem::Bank::BranchCollection)
     end
   end
 
-  describe Bank::BranchCollection do
+  describe ZenginBankGem::Bank::BranchCollection do
     describe 'ある取得した支店の名前とコードが正しく取得出来ている' do
       context '愛知銀行一宮支店の場合' do
         

--- a/spec/scraper_spec.rb
+++ b/spec/scraper_spec.rb
@@ -1,14 +1,14 @@
 require_relative 'spec_helper'
 require 'vcr'
 
-RSpec.describe Scraper do
+RSpec.describe ZenginBankGem::Scraper do
 
     VCR.use_cassette("scraper_spec", :record => :new_episodes) do
       describe '#get_banks_list_pages' do
         describe '全ての銀行かなページを取得出来ている' do
           
           before do
-            @bank_pages = Scraper.instance.get_banks_list_pages
+            @bank_pages = ZenginBankGem::Scraper.instance.get_banks_list_pages
           end
 
           it 'Pageオブジェクトが返っている' do
@@ -33,10 +33,10 @@ RSpec.describe Scraper do
             
             before do
               tbank = 
-                Zengin.banks.each.find do |bank|
+                ZenginBankGem.banks.each.find do |bank|
                   bank.bank_name == "愛知県警察信用組合"
                 end
-              @branch_pages = Scraper.instance.get_branch_list_pages(tbank.branch_kana_page)
+              @branch_pages = ZenginBankGem::Scraper.instance.get_branch_list_pages(tbank.branch_kana_page)
             end
 
             it 'Pageオブジェクトが返っている' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,10 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'zengin_bank_gem'
 
+RSpec.configure do |config|
+  config.filter_run_excluding full_dump: true
+end
+
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/cassettes'
   c.hook_into :webmock

--- a/spec/zengin_bank_gem_spec.rb
+++ b/spec/zengin_bank_gem_spec.rb
@@ -2,20 +2,20 @@ require 'vcr'
 require_relative './spec_helper'
 
 
-RSpec.describe Zengin, vcr: { cassette_name: 'zengin_spec', :record => :new_episodes } do
+RSpec.describe ZenginBankGem, vcr: { cassette_name: 'zengin_spec', :record => :new_episodes } do
 
   attr_accessor :banks
   before do
-    @banks = Zengin.banks
+    @banks = ZenginBankGem.banks
   end
 
   describe '#banks' do
-    it 'banksを呼んだ時にBankCollectionが返る' do
-      expect(Zengin.banks).to be_kind_of(Zengin::BankCollection)
+    it 'banksを呼んだ時にZenginBankGem::BankCollectionが返る' do
+      expect(ZenginBankGem.banks).to be_kind_of(ZenginBankGem::BankCollection)
     end
   end
 
-  describe Zengin::BankCollection do
+  describe ZenginBankGem::BankCollection do
     describe 'ある取得した銀行の名前とコードが正しく取得出来ている' do
       context '松本信用金庫の場合' do
         it 'コードは1391になる' do
@@ -57,7 +57,7 @@ RSpec.describe Zengin, vcr: { cassette_name: 'zengin_spec', :record => :new_epis
   VCR.use_cassette("mk_csv", :record => :new_episodes) do
     describe 'csv出力' do
       it 'csv全件出力される' do
-        expect(Zengin.mk_csv_file('zengin_test2')).not_to be_empty
+        expect(ZenginBankGem.mk_csv_file('zengin_test2')).not_to be_empty
       end
     end
   end

--- a/spec/zengin_bank_gem_spec.rb
+++ b/spec/zengin_bank_gem_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ZenginBankGem, vcr: { cassette_name: 'zengin_spec', :record => :n
 
   VCR.use_cassette("mk_csv", :record => :new_episodes) do
     describe 'csv出力' do
-      it 'csv全件出力される' do
+      it 'csv全件出力される', full_dump: true do
         expect(ZenginBankGem.mk_csv_file('zengin_test2')).not_to be_empty
       end
     end


### PR DESCRIPTION
- テストが通らなかったのでPassするように修正
- `.rspec`の追加
- CSVの全件出力テストを標準で実行しないように修正

``` sh
# 通常（CSVの全件出力のテストを実行しない）場合
$ bundle exec rspec
Run options: exclude {:full_dump=>true}

ZenginBankGem::Bank
  #branches
    branchesを呼んだ時にZenginBankGem::Bank::BranchCollectionが返る
  ZenginBankGem::Bank::BranchCollection
    ある取得した支店の名前とコードが正しく取得出来ている
      愛知銀行一宮支店の場合
        支店コードは769になる
        よみがなは"ｲﾁﾉﾐﾔ"になる
    あるかなの支店が全て取得出来ている
      愛知銀行の"ほ"の場合
        4つの支店がある
        重複がない
        本店営業部を含んでいる

ZenginBankGem::Scraper
  #get_banks_list_pages
    全ての銀行かなページを取得出来ている
      Pageオブジェクトが返っている
      44種類ページが返っている
      重複がない
  #get_branch_list_pages
    全てのかなページを取得出来ている
      Pageオブジェクトが返っている
      45種類ページが返っている
      重複がない

ZenginBankGem
  #banks
    banksを呼んだ時にZenginBankGem::BankCollectionが返る
  ZenginBankGem::BankCollection
    ある取得した銀行の名前とコードが正しく取得出来ている
      松本信用金庫の場合
        コードは1391になる
  あるかなの銀行が全て取得出来ている
    "の"の場合
      9つの金融機関がある
      重複がない
      延岡信用金庫を含んでいる

Finished in 1 minute 34.29 seconds (files took 0.75013 seconds to load)
17 examples, 0 failures

bundle exec rspec  41.20s user 1.45s system 44% cpu 1:35.84 total
```

``` sh
# CSVの全件出力テストを実行する場合
$ bundle exec rspec --tag full_dump
Run options: include {:full_dump=>true}

ZenginBankGem
  csv出力

# CSV出力は完了するが、テストが終わらない
```
